### PR TITLE
Some cleanup for 50052

### DIFF
--- a/src/js/_enqueues/wp/updates.js
+++ b/src/js/_enqueues/wp/updates.js
@@ -2470,18 +2470,13 @@
 		 * @since 4.2.0
 		 */
 		$( window ).on( 'beforeunload', wp.updates.beforeunload );
-	} );
 
-	/**
-	 * Click handler for enabling and disabling plugin and theme auto-updates.
-	 *
-	 * @since 5.5.0
-	 *
-	 * TODO: this needs to be refactored to be like the remainder of the handlers
-	 *       in this file.
-	 */
-	$( document ).ready( function() {
-		$( $document ).on( 'click', '.column-auto-updates a.toggle-auto-update, .theme-overlay a.toggle-auto-update', function( event ) {
+		/**
+		 * Click handler for enabling and disabling plugin and theme auto-updates.
+		 *
+		 * @since 5.5.0
+		 */
+		$document.on( 'click', '.column-auto-updates a.toggle-auto-update, .theme-overlay a.toggle-auto-update', function( event ) {
 			var data, asset, type, $parent;
 			var $anchor = $( this ),
 				action = $anchor.attr( 'data-wp-action' ),
@@ -2522,14 +2517,12 @@
 			$parent.find( '.notice.error' ).addClass( 'hidden' );
 
 			// Show loading status.
-			// TODO: make it readable when network is fast, or possibly remove the interim text change.
 			if ( 'enable' === action ) {
 				$label.text( wp.updates.l10n.autoUpdatesEnabling );
 			} else {
 				$label.text( wp.updates.l10n.autoUpdatesDisabling );
 			}
 
-			// TODO: Needs design review - the link text jumps under the mouse (part may get selected).
 			$anchor.find( '.dashicons-update' ).removeClass( 'hidden' );
 
 			data = {
@@ -2546,9 +2539,8 @@
 					var href = $anchor.attr( 'href' );
 
 					if ( ! response.success ) {
-						// if WP returns 0 for response (which can happen in a few cases
-						// that aren't quite failures), output the general error message,
-						// since we won't have response.data.error.
+						// if WP returns 0 for response (which can happen in a few cases),
+						// output the general error message since we won't have response.data.error.
 						if ( response.data && response.data.error ) {
 							errorMessage = response.data.error;
 						} else {

--- a/src/wp-admin/includes/class-wp-automatic-updater.php
+++ b/src/wp-admin/includes/class-wp-automatic-updater.php
@@ -158,7 +158,7 @@ class WP_Automatic_Updater {
 		// Next up, is this an item we can update?
 		if ( 'core' === $type ) {
 			$update = Core_Upgrader::should_update_to_version( $item->current );
-		} else {
+		} elseif ( 'plugin' === $type || 'theme' === $type ) {
 			$update = ! empty( $item->autoupdate );
 
 			if ( ! $update && wp_is_auto_update_enabled_for_type( $type ) ) {
@@ -166,6 +166,8 @@ class WP_Automatic_Updater {
 				$auto_updates = (array) get_site_option( "auto_update_{$type}s", array() );
 				$update       = in_array( $item->{$type}, $auto_updates, true );
 			}
+		} else {
+			$update = ! empty( $item->autoupdate );
 		}
 
 		/**

--- a/src/wp-admin/includes/class-wp-automatic-updater.php
+++ b/src/wp-admin/includes/class-wp-automatic-updater.php
@@ -978,8 +978,7 @@ class WP_Automatic_Updater {
 			$body[] = __( 'The following plugins failed to update:' );
 			// List failed updates.
 			foreach ( $failed_updates['plugin'] as $item ) {
-				/* translators: %s: Name of the related plugin. */
-				$body[] = ' ' . sprintf( __( '- %s' ), $item->name );
+				$body[] = "- {$item->name}";
 			}
 			$body[] = "\n";
 		}
@@ -988,8 +987,7 @@ class WP_Automatic_Updater {
 			$body[] = __( 'The following themes failed to update:' );
 			// List failed updates.
 			foreach ( $failed_updates['theme'] as $item ) {
-				/* translators: %s: Name of the related plugin. */
-				$body[] = ' ' . sprintf( __( '- %s' ), $item->name );
+				$body[] = "- {$item->name}";
 			}
 			$body[] = "\n";
 		}
@@ -998,8 +996,7 @@ class WP_Automatic_Updater {
 			$body[] = __( 'The following plugins were successfully updated:' );
 			// List successful updates.
 			foreach ( $successful_updates['plugin'] as $item ) {
-				/* translators: %s: Name of the related plugin. */
-				$body[] = ' ' . sprintf( __( '- %s' ), $item->name );
+				$body[] = "- {$item->name}";
 			}
 			$body[] = "\n";
 		}
@@ -1008,8 +1005,7 @@ class WP_Automatic_Updater {
 			$body[] = __( 'The following themes were successfully updated:' );
 			// List successful updates.
 			foreach ( $successful_updates['theme'] as $item ) {
-				/* translators: %s: Name of the related plugin. */
-				$body[] = ' ' . sprintf( __( '- %s' ), $item->name );
+				$body[] = "- {$item->name}";
 			}
 			$body[] = "\n";
 		}

--- a/src/wp-admin/includes/class-wp-automatic-updater.php
+++ b/src/wp-admin/includes/class-wp-automatic-updater.php
@@ -158,14 +158,14 @@ class WP_Automatic_Updater {
 		// Next up, is this an item we can update?
 		if ( 'core' === $type ) {
 			$update = Core_Upgrader::should_update_to_version( $item->current );
-		} elseif ( 'plugin' === $type || 'theme' === $type ) {
-			$update = false;
-			if ( wp_is_auto_update_enabled_for_type( $type ) ) {
-				$auto_updates = (array) get_site_option( "auto_update_{$type}s", array() );
-				$update       = in_array( $item->{$type}, $auto_updates, true ) || ! empty( $item->autoupdate );
-			}
 		} else {
 			$update = ! empty( $item->autoupdate );
+
+			if ( ! $update && wp_is_auto_update_enabled_for_type( $type ) ) {
+				// Check if the site admin has enabled auto-updates by default for the specific item.
+				$auto_updates = (array) get_site_option( "auto_update_{$type}s", array() );
+				$update       = in_array( $item->{$type}, $auto_updates, true );
+			}
 		}
 
 		/**

--- a/src/wp-admin/includes/class-wp-debug-data.php
+++ b/src/wp-admin/includes/class-wp-debug-data.php
@@ -856,10 +856,14 @@ class WP_Debug_Data {
 		}
 
 		// List all available plugins.
-		$plugins              = get_plugins();
-		$plugin_updates       = get_plugin_updates();
-		$auto_updates         = array();
-		$auto_updates_enabled = wp_is_auto_update_enabled_for_type( 'plugin' );
+		$plugins        = get_plugins();
+		$plugin_updates = get_plugin_updates();
+		$auto_updates   = array();
+
+		$auto_updates_enabled      = wp_is_auto_update_enabled_for_type( 'plugin' );
+		$auto_updates_enabled_str  = __( 'Auto-updates enabled' );
+		$auto_updates_disabled_str = __( 'Auto-updates disabled' );
+
 		if ( $auto_updates_enabled ) {
 			$auto_updates = (array) get_site_option( 'auto_update_plugins', array() );
 		}
@@ -899,11 +903,11 @@ class WP_Debug_Data {
 
 			if ( $auto_updates_enabled ) {
 				if ( in_array( $plugin_path, $auto_updates, true ) ) {
-					$plugin_version_string       .= ' | ' . __( 'Auto-updates enabled' );
-					$plugin_version_string_debug .= ', ' . __( 'Auto-updates enabled' );
+					$plugin_version_string       .= ' | ' . $auto_updates_enabled_str;
+					$plugin_version_string_debug .= ', ' . $auto_updates_enabled_str;
 				} else {
-					$plugin_version_string       .= ' | ' . __( 'Auto-updates disabled' );
-					$plugin_version_string_debug .= ', ' . __( 'Auto-updates disabled' );
+					$plugin_version_string       .= ' | ' . $auto_updates_disabled_str;
+					$plugin_version_string_debug .= ', ' . $auto_updates_disabled_str;
 				}
 			}
 
@@ -1123,11 +1127,11 @@ class WP_Debug_Data {
 
 			if ( $auto_updates_enabled ) {
 				if ( in_array( $theme_slug, $auto_updates ) ) {
-					$theme_version_string       .= ' | ' . __( 'Auto-updates enabled' );
-					$theme_version_string_debug .= ',' . __( 'Auto-updates enabled' );
+					$theme_version_string       .= ' | ' . $auto_updates_enabled_str;
+					$theme_version_string_debug .= ',' . $auto_updates_enabled_str;
 				} else {
-					$theme_version_string       .= ' | ' . __( 'Auto-updates disabled' );
-					$theme_version_string_debug .= ', ' . __( 'Auto-updates disabled' );
+					$theme_version_string       .= ' | ' . $auto_updates_disabled_str;
+					$theme_version_string_debug .= ', ' . $auto_updates_disabled_str;
 				}
 			}
 

--- a/src/wp-admin/includes/class-wp-ms-themes-list-table.php
+++ b/src/wp-admin/includes/class-wp-ms-themes-list-table.php
@@ -718,27 +718,39 @@ class WP_MS_Themes_List_Table extends WP_List_Table {
 		$stylesheet = $theme->get_stylesheet();
 
 		if ( in_array( $stylesheet, $auto_updates, true ) ) {
-			$text                   = __( 'Disable auto-updates', 'wp-autoupdates' );
-			$auto_update_time_class = '';
-			$action                 = 'disable';
+			$text       = __( 'Disable auto-updates' );
+			$action     = 'disable';
+			$time_class = '';
 		} else {
-			$text                   = __( 'Enable auto-updates', 'wp-autoupdates' );
-			$action                 = 'enable';
-			$auto_update_time_class = ' hidden';
+			$text       = __( 'Enable auto-updates' );
+			$action     = 'enable';
+			$time_class = ' hidden';
 		}
 
-		printf(
-			'<a href="%s" class="toggle-auto-update" data-wp-action="%s"><span class="dashicons dashicons-update spin hidden"></span><span class="label">%s</span></a>',
-			wp_nonce_url( 'themes.php?action=' . $action . '-auto-update&amp;theme=' . urlencode( $stylesheet ) . '&amp;paged=' . $page . '&amp;theme_status=' . $status, 'updates' ),
-			$action,
-			$text
+		$query_args = array(
+			'action'       => "{$action}-auto-update",
+			'theme'        => $stylesheet,
+			'paged'        => $page,
+			'theme_status' => $status,
 		);
+
+		$url = add_query_arg( $query_args, 'themes.php' );
+
+		printf(
+			'<a href="%s" class="toggle-auto-update" data-wp-action="%s">',
+			wp_nonce_url( $url, 'updates' ),
+			$action
+		);
+
+		echo '<span class="dashicons dashicons-update spin hidden"></span>';
+		echo '<span class="label">' . $text . '</span>';
+		echo '</a>';
 
 		$available_updates = get_site_transient( 'update_themes' );
 		if ( isset( $available_updates->response[ $stylesheet ] ) ) {
 			printf(
 				'<div class="auto-update-time%s">%s</div>',
-				$auto_update_time_class,
+				$time_class,
 				wp_get_auto_update_message()
 			);
 		}

--- a/src/wp-admin/includes/class-wp-plugins-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugins-list-table.php
@@ -1041,27 +1041,39 @@ class WP_Plugins_List_Table extends WP_List_Table {
 					echo "<td class='column-auto-updates{$extra_classes}'>";
 
 					if ( in_array( $plugin_file, $auto_updates, true ) ) {
-						$text                   = __( 'Disable auto-updates', 'wp-autoupdates' );
-						$action                 = 'disable';
-						$auto_update_time_class = '';
+						$text       = __( 'Disable auto-updates' );
+						$action     = 'disable';
+						$time_class = '';
 					} else {
-						$text                   = __( 'Enable auto-updates', 'wp-autoupdates' );
-						$action                 = 'enable';
-						$auto_update_time_class = ' hidden';
+						$text       = __( 'Enable auto-updates' );
+						$action     = 'enable';
+						$time_class = ' hidden';
 					}
 
-					printf(
-						'<a href="%s" class="toggle-auto-update" data-wp-action="%s"><span class="dashicons dashicons-update spin hidden"></span><span class="label">%s</span></a>',
-						wp_nonce_url( 'plugins.php?action=' . $action . '-auto-update&amp;plugin=' . urlencode( $plugin_file ) . '&amp;paged=' . $page . '&amp;plugin_status=' . $status, 'updates' ),
-						$action,
-						$text
+					$query_args = array(
+						'action'        => "{$action}-auto-update",
+						'plugin'        => $plugin_file,
+						'paged'         => $page,
+						'plugin_status' => $status,
 					);
+
+					$url = add_query_arg( $query_args, 'plugins.php' );
+
+					printf(
+						'<a href="%s" class="toggle-auto-update" data-wp-action="%s">',
+						wp_nonce_url( $url, 'updates' ),
+						$action
+					);
+
+					echo '<span class="dashicons dashicons-update spin hidden"></span>';
+					echo '<span class="label">' . $text . '</span>';
+					echo '</a>';
 
 					$available_updates = get_site_transient( 'update_plugins' );
 					if ( isset( $available_updates->response[ $plugin_file ] ) ) {
 						printf(
 							'<div class="auto-update-time%s">%s</div>',
-							$auto_update_time_class,
+							$time_class,
 							wp_get_auto_update_message()
 						);
 					}

--- a/src/wp-admin/network/themes.php
+++ b/src/wp-admin/network/themes.php
@@ -217,92 +217,56 @@ if ( $action ) {
 			);
 			exit;
 		case 'enable-auto-update':
-			if ( ! ( current_user_can( 'update_themes' ) && wp_is_auto_update_enabled_for_type( 'theme' ) ) ) {
-				wp_die( __( 'Sorry, you are not allowed to enable themes automatic updates.' ) );
-			}
-
-			check_admin_referer( 'updates' );
-
-			$all_items    = wp_get_themes();
-			$auto_updates = (array) get_site_option( 'auto_update_themes', array() );
-
-			$auto_updates[] = $_GET['theme'];
-			$auto_updates   = array_unique( $auto_updates );
-			// Remove themes that have been deleted since the site option was last updated.
-			$auto_updates = array_intersect( $auto_updates, array_keys( $all_items ) );
-
-			update_site_option( 'auto_update_themes', $auto_updates );
-
-			wp_safe_redirect( add_query_arg( 'enabled-auto-update', 1, $referer ) );
-			exit;
 		case 'disable-auto-update':
-			if ( ! ( current_user_can( 'update_themes' ) && wp_is_auto_update_enabled_for_type( 'theme' ) ) ) {
-				wp_die( __( 'Sorry, you are not allowed to disable themes automatic updates.' ) );
-			}
-
-			check_admin_referer( 'updates' );
-
-			$all_items    = wp_get_themes();
-			$auto_updates = (array) get_site_option( 'auto_update_themes', array() );
-
-			$auto_updates = array_diff( $auto_updates, array( $_GET['theme'] ) );
-			// Remove themes that have been deleted since the site option was last updated.
-			$auto_updates = array_intersect( $auto_updates, array_keys( $all_items ) );
-
-			update_site_option( 'auto_update_themes', $auto_updates );
-
-			wp_safe_redirect( add_query_arg( 'disabled-auto-update', 1, $referer ) );
-			exit;
 		case 'enable-auto-update-selected':
-			if ( ! ( current_user_can( 'update_themes' ) && wp_is_auto_update_enabled_for_type( 'theme' ) ) ) {
-				wp_die( __( 'Sorry, you are not allowed to enable themes automatic updates.' ) );
-			}
-
-			check_admin_referer( 'bulk-themes' );
-
-			$themes = isset( $_POST['checked'] ) ? (array) wp_unslash( $_POST['checked'] ) : array();
-
-			$all_items    = wp_get_themes();
-			$auto_updates = (array) get_site_option( 'auto_update_themes', array() );
-
-			$new_auto_updates = array_merge( $auto_updates, $themes );
-			$new_auto_updates = array_unique( $new_auto_updates );
-			// Remove themes that have been deleted since the site option was last updated.
-			$new_auto_updates = array_intersect( $new_auto_updates, array_keys( $all_items ) );
-
-			update_site_option( 'auto_update_themes', $new_auto_updates );
-
-			wp_safe_redirect( add_query_arg( 'enabled-auto-update', count( $themes ), $referer ) );
-			exit;
 		case 'disable-auto-update-selected':
 			if ( ! ( current_user_can( 'update_themes' ) && wp_is_auto_update_enabled_for_type( 'theme' ) ) ) {
-				wp_die( __( 'Sorry, you are not allowed to disable themes automatic updates.' ) );
+				wp_die( __( 'Sorry, you are not allowed to change themes automatic update settings.' ) );
 			}
 
-			check_admin_referer( 'bulk-themes' );
+			if ( 'enable-auto-update' === $action || 'disable-auto-update' === $action ) {
+				check_admin_referer( 'updates' );
+			} else {
+				if ( empty( $_POST['checked'] ) ) {
+					// Nothing to do.
+					wp_safe_redirect( add_query_arg( 'error', 'none', $referer ) );
+					exit;
+				}
 
-			$themes = isset( $_POST['checked'] ) ? (array) wp_unslash( $_POST['checked'] ) : array();
+				check_admin_referer( 'bulk-themes' );
+			}
 
-			$all_items    = wp_get_themes();
 			$auto_updates = (array) get_site_option( 'auto_update_themes', array() );
 
-			$new_auto_updates = array_diff( $auto_updates, $themes );
+			if ( 'enable-auto-update' === $action ) {
+				$auto_updates[] = $_GET['theme'];
+				$auto_updates   = array_unique( $auto_updates );
+				$referer = add_query_arg( 'enabled-auto-update', 1, $referer );
+			} elseif ( 'disable-auto-update' === $action ) {
+				$auto_updates = array_diff( $auto_updates, array( $_GET['theme'] ) );
+				$referer = add_query_arg( 'disabled-auto-update', 1, $referer );
+			} else {
+				// Bulk enable/disable.
+				$themes = (array) wp_unslash( $_POST['checked'] );
 
-			if ( $new_auto_updates == $auto_updates ) {
-				if ( false === strpos( $referer, '/network/themes.php' ) ) {
-					wp_redirect( network_admin_url( 'themes.php?disabled-auto-update=1' ) );
+				if ( 'enable-auto-update-selected' === $action ) {
+					$auto_updates = array_merge( $auto_updates, $themes );
+					$auto_updates = array_unique( $auto_updates );
+					$referer = add_query_arg( 'enabled-auto-update', count( $themes ), $referer );
 				} else {
-					wp_safe_redirect( $referer );
+					$auto_updates = array_diff( $auto_updates, $themes );
+					$referer = add_query_arg( 'disabled-auto-update', count( $themes ), $referer );
 				}
-				exit;
 			}
 
-			// Remove themes that have been deleted since the site option was last updated.
-			$new_auto_updates = array_intersect( $new_auto_updates, array_keys( $all_items ) );
+			$all_items = wp_get_themes();
 
-			update_site_option( 'auto_update_themes', $new_auto_updates );
+			// Remove themes that don't exist or have been deleted since the option was last updated.
+			$auto_updates = array_intersect( $auto_updates, array_keys( $all_items ) );
 
-			wp_safe_redirect( add_query_arg( 'disabled-auto-update', count( $themes ), $referer ) );
+			update_site_option( 'auto_update_themes', $auto_updates );
+
+			wp_safe_redirect( $referer );
 			exit;
 		default:
 			$themes = isset( $_POST['checked'] ) ? (array) $_POST['checked'] : array();
@@ -380,7 +344,7 @@ if ( isset( $_REQUEST['s'] ) && strlen( $_REQUEST['s'] ) ) {
 <?php
 if ( isset( $_GET['enabled'] ) ) {
 	$enabled = absint( $_GET['enabled'] );
-	if ( 1 == $enabled ) {
+	if ( 1 === $enabled ) {
 		$message = __( 'Theme enabled.' );
 	} else {
 		/* translators: %s: Number of themes. */
@@ -389,7 +353,7 @@ if ( isset( $_GET['enabled'] ) ) {
 	echo '<div id="message" class="updated notice is-dismissible"><p>' . sprintf( $message, number_format_i18n( $enabled ) ) . '</p></div>';
 } elseif ( isset( $_GET['disabled'] ) ) {
 	$disabled = absint( $_GET['disabled'] );
-	if ( 1 == $disabled ) {
+	if ( 1 === $disabled ) {
 		$message = __( 'Theme disabled.' );
 	} else {
 		/* translators: %s: Number of themes. */
@@ -398,7 +362,7 @@ if ( isset( $_GET['enabled'] ) ) {
 	echo '<div id="message" class="updated notice is-dismissible"><p>' . sprintf( $message, number_format_i18n( $disabled ) ) . '</p></div>';
 } elseif ( isset( $_GET['deleted'] ) ) {
 	$deleted = absint( $_GET['deleted'] );
-	if ( 1 == $deleted ) {
+	if ( 1 === $deleted ) {
 		$message = __( 'Theme deleted.' );
 	} else {
 		/* translators: %s: Number of themes. */
@@ -407,7 +371,7 @@ if ( isset( $_GET['enabled'] ) ) {
 	echo '<div id="message" class="updated notice is-dismissible"><p>' . sprintf( $message, number_format_i18n( $deleted ) ) . '</p></div>';
 } elseif ( isset( $_GET['enabled-auto-update'] ) ) {
 	$enabled = absint( $_GET['enabled-auto-update'] );
-	if ( 1 == $enabled ) {
+	if ( 1 === $enabled ) {
 		$message = __( 'Theme will be auto-updated.' );
 	} else {
 		/* translators: %s: Number of themes. */
@@ -416,25 +380,17 @@ if ( isset( $_GET['enabled'] ) ) {
 	echo '<div id="message" class="updated notice is-dismissible"><p>' . sprintf( $message, number_format_i18n( $enabled ) ) . '</p></div>';
 } elseif ( isset( $_GET['disabled-auto-update'] ) ) {
 	$disabled = absint( $_GET['disabled-auto-update'] );
-	if ( 1 == $disabled ) {
+	if ( 1 === $disabled ) {
 		$message = __( 'Theme will no longer be auto-updated.' );
 	} else {
 		/* translators: %s: Number of themes. */
 		$message = _n( '%s theme will no longer be auto-updated.', '%s themes will no longer be auto-updated.', $disabled );
 	}
 	echo '<div id="message" class="updated notice is-dismissible"><p>' . sprintf( $message, number_format_i18n( $disabled ) ) . '</p></div>';
-} elseif ( isset( $_GET['error'] ) && 'none' == $_GET['error'] ) {
+} elseif ( isset( $_GET['error'] ) && 'none' === $_GET['error'] ) {
 	echo '<div id="message" class="error notice is-dismissible"><p>' . __( 'No theme selected.' ) . '</p></div>';
-} elseif ( isset( $_GET['error'] ) && 'main' == $_GET['error'] ) {
+} elseif ( isset( $_GET['error'] ) && 'main' === $_GET['error'] ) {
 	echo '<div class="error notice is-dismissible"><p>' . __( 'You cannot delete a theme while it is active on the main site.' ) . '</p></div>';
-} elseif ( isset( $_GET['error'] ) && 'none' == $_GET['error'] ) {
-	echo '<div id="message" class="error notice is-dismissible"><p>' . __( 'No theme selected.' ) . '</p></div>';
-} elseif ( isset( $_GET['disable-auto-update'] ) ) {
-	echo '<div id="message" class="updated notice is-dismissible"><p>' . __( 'Theme will no longer be auto-updated.' ) . '</p></div>';
-} elseif ( isset( $_GET['enable-autoupdate-multi'] ) ) {
-	echo '<div id="message" class="updated notice is-dismissible"><p>' . __( 'Themes will be auto-updated.' ) . '</p></div>';
-} elseif ( isset( $_GET['disable-autoupdate-multi'] ) ) {
-	echo '<div id="message" class="updated notice is-dismissible"><p>' . __( 'Themes will no longer be auto-updated.' ) . '</p></div>';
 }
 
 ?>

--- a/src/wp-admin/network/themes.php
+++ b/src/wp-admin/network/themes.php
@@ -22,7 +22,15 @@ $action = $wp_list_table->current_action();
 $s = isset( $_REQUEST['s'] ) ? $_REQUEST['s'] : '';
 
 // Clean up request URI from temporary args for screen options/paging uri's to work as expected.
-$temp_args              = array( 'enabled', 'disabled', 'deleted', 'error', 'enabled-auto-update', 'disabled-auto-update' );
+$temp_args = array(
+	'enabled',
+	'disabled',
+	'deleted',
+	'error',
+	'enabled-auto-update',
+	'disabled-auto-update',
+);
+
 $_SERVER['REQUEST_URI'] = remove_query_arg( $temp_args, $_SERVER['REQUEST_URI'] );
 $referer                = remove_query_arg( $temp_args, wp_get_referer() );
 

--- a/src/wp-admin/network/themes.php
+++ b/src/wp-admin/network/themes.php
@@ -131,8 +131,8 @@ if ( $action ) {
 				require_once ABSPATH . 'wp-admin/admin-header.php';
 				$themes_to_delete = count( $themes );
 				?>
-			<div class="wrap">
-				<?php if ( 1 == $themes_to_delete ) : ?>
+				<div class="wrap">
+				<?php if ( 1 === $themes_to_delete ) : ?>
 					<h1><?php _e( 'Delete Theme' ); ?></h1>
 					<div class="error"><p><strong><?php _e( 'Caution:' ); ?></strong> <?php _e( 'This theme may be active on other sites in the network.' ); ?></p></div>
 					<p><?php _e( 'You are about to remove the following theme:' ); ?></p>
@@ -153,7 +153,7 @@ if ( $action ) {
 					}
 					?>
 					</ul>
-				<?php if ( 1 == $themes_to_delete ) : ?>
+				<?php if ( 1 === $themes_to_delete ) : ?>
 					<p><?php _e( 'Are you sure you want to delete this theme?' ); ?></p>
 				<?php else : ?>
 					<p><?php _e( 'Are you sure you want to delete these themes?' ); ?></p>
@@ -162,27 +162,28 @@ if ( $action ) {
 					<input type="hidden" name="verify-delete" value="1" />
 					<input type="hidden" name="action" value="delete-selected" />
 					<?php
+
 					foreach ( (array) $themes as $theme ) {
 						echo '<input type="hidden" name="checked[]" value="' . esc_attr( $theme ) . '" />';
 					}
 
-						wp_nonce_field( 'bulk-themes' );
+					wp_nonce_field( 'bulk-themes' );
 
-					if ( 1 == $themes_to_delete ) {
+					if ( 1 === $themes_to_delete ) {
 						submit_button( __( 'Yes, delete this theme' ), '', 'submit', false );
 					} else {
 						submit_button( __( 'Yes, delete these themes' ), '', 'submit', false );
 					}
+
 					?>
 				</form>
-				<?php
-				$referer = wp_get_referer();
-				?>
+				<?php $referer = wp_get_referer(); ?>
 				<form method="post" action="<?php echo $referer ? esc_url( $referer ) : ''; ?>" style="display:inline;">
 					<?php submit_button( __( 'No, return me to the theme list' ), '', 'submit', false ); ?>
 				</form>
-			</div>
+				</div>
 				<?php
+
 				require_once ABSPATH . 'wp-admin/admin-footer.php';
 				exit;
 			} // End if verify-delete.
@@ -241,10 +242,10 @@ if ( $action ) {
 			if ( 'enable-auto-update' === $action ) {
 				$auto_updates[] = $_GET['theme'];
 				$auto_updates   = array_unique( $auto_updates );
-				$referer = add_query_arg( 'enabled-auto-update', 1, $referer );
+				$referer        = add_query_arg( 'enabled-auto-update', 1, $referer );
 			} elseif ( 'disable-auto-update' === $action ) {
 				$auto_updates = array_diff( $auto_updates, array( $_GET['theme'] ) );
-				$referer = add_query_arg( 'disabled-auto-update', 1, $referer );
+				$referer      = add_query_arg( 'disabled-auto-update', 1, $referer );
 			} else {
 				// Bulk enable/disable.
 				$themes = (array) wp_unslash( $_POST['checked'] );
@@ -252,10 +253,10 @@ if ( $action ) {
 				if ( 'enable-auto-update-selected' === $action ) {
 					$auto_updates = array_merge( $auto_updates, $themes );
 					$auto_updates = array_unique( $auto_updates );
-					$referer = add_query_arg( 'enabled-auto-update', count( $themes ), $referer );
+					$referer      = add_query_arg( 'enabled-auto-update', count( $themes ), $referer );
 				} else {
 					$auto_updates = array_diff( $auto_updates, $themes );
-					$referer = add_query_arg( 'disabled-auto-update', count( $themes ), $referer );
+					$referer      = add_query_arg( 'disabled-auto-update', count( $themes ), $referer );
 				}
 			}
 
@@ -402,7 +403,7 @@ if ( isset( $_GET['enabled'] ) ) {
 <?php
 $wp_list_table->views();
 
-if ( 'broken' == $status ) {
+if ( 'broken' === $status ) {
 	echo '<p class="clear">' . __( 'The following themes are installed but incomplete.' ) . '</p>';
 }
 ?>

--- a/src/wp-admin/plugins.php
+++ b/src/wp-admin/plugins.php
@@ -22,7 +22,20 @@ $plugin = isset( $_REQUEST['plugin'] ) ? wp_unslash( $_REQUEST['plugin'] ) : '';
 $s      = isset( $_REQUEST['s'] ) ? urlencode( wp_unslash( $_REQUEST['s'] ) ) : '';
 
 // Clean up request URI from temporary args for screen options/paging uri's to work as expected.
-$_SERVER['REQUEST_URI'] = remove_query_arg( array( 'error', 'deleted', 'activate', 'activate-multi', 'deactivate', 'deactivate-multi', 'enable-auto-update', 'disable-auto-update', 'enable-auto-update-multi', 'disable-auto-update-multi', '_error_nonce' ), $_SERVER['REQUEST_URI'] );
+$query_args_to_remove = array(
+	'error',
+	'deleted',
+	'activate',
+	'activate-multi',
+	'deactivate',
+	'deactivate-multi',
+	'enabled-auto-update',
+	'disabled-auto-update',
+	'enabled-auto-update-multi',
+	'disabled-auto-update-multi',
+	'_error_nonce',
+);
+$_SERVER['REQUEST_URI'] = remove_query_arg( $query_args_to_remove, $_SERVER['REQUEST_URI'] );
 
 wp_enqueue_script( 'updates' );
 
@@ -415,130 +428,76 @@ if ( $action ) {
 			exit;
 
 		case 'enable-auto-update':
-			if ( ! current_user_can( 'update_plugins' ) || ! wp_is_auto_update_enabled_for_type( 'plugin' ) ) {
-				wp_die( __( 'Sorry, you are not allowed to enable plugins automatic updates.' ) );
-			}
-
-			if ( is_multisite() && ! is_network_admin() ) {
-				wp_die( __( 'Please connect to your network admin to manage plugins automatic updates.' ) );
-			}
-
-			check_admin_referer( 'updates' );
-
-			if ( empty( $plugin ) ) {
-				wp_redirect( self_admin_url( "plugins.php?plugin_status=$status&paged=$page&s=$s" ) );
-				exit;
-			}
-
-			/** This filter is documented in wp-admin/includes/class-wp-plugins-list-table.php */
-			$all_items    = apply_filters( 'all_plugins', get_plugins() );
-			$auto_updates = (array) get_site_option( 'auto_update_plugins', array() );
-
-			$auto_updates[] = $plugin;
-			$auto_updates   = array_unique( $auto_updates );
-			// Remove plugins that have been deleted since the site option was last updated.
-			$auto_updates = array_intersect( $auto_updates, array_keys( $all_items ) );
-
-			update_site_option( 'auto_update_plugins', $auto_updates );
-
-			wp_redirect( self_admin_url( "plugins.php?enable-auto-update=true&plugin_status=$status&paged=$page&s=$s" ) );
-			exit;
-
 		case 'disable-auto-update':
+		case 'enable-auto-update-selected':
+		case 'disable-auto-update-selected':
 			if ( ! current_user_can( 'update_plugins' ) || ! wp_is_auto_update_enabled_for_type( 'plugin' ) ) {
-				wp_die( __( 'Sorry, you are not allowed to disable plugins automatic updates.' ) );
+				wp_die( __( 'Sorry, you are not allowed to manage plugins automatic updates.' ) );
 			}
 
 			if ( is_multisite() && ! is_network_admin() ) {
 				wp_die( __( 'Please connect to your network admin to manage plugins automatic updates.' ) );
 			}
 
-			check_admin_referer( 'updates' );
+			$redirect = self_admin_url( "plugins.php?plugin_status={$status}&paged={$page}&s={$s}" );
 
-			if ( empty( $plugin ) ) {
-				wp_redirect( self_admin_url( "plugins.php?plugin_status=$status&paged=$page&s=$s" ) );
-				exit;
+			if ( 'enable-auto-update' === $action || 'disable-auto-update' === $action ) {
+				if ( empty( $plugin ) ) {
+					wp_redirect( $redirect );
+					exit;
+				}
+
+				check_admin_referer( 'updates' );
+			} else {
+				if ( empty( $_POST['checked'] ) ) {
+					wp_redirect( $redirect );
+					exit;
+				}
+
+				check_admin_referer( 'bulk-plugins' );
+			}
+
+			$auto_updates = (array) get_site_option( 'auto_update_plugins', array() );
+
+			if ( 'enable-auto-update' === $action ) {
+				$auto_updates[] = $plugin;
+				$auto_updates   = array_unique( $auto_updates );
+				$redirect = add_query_arg( array( 'enabled-auto-update' => 'true' ), $redirect );
+			} elseif ( 'disable-auto-update' === $action ) {
+				$auto_updates = array_diff( $auto_updates, array( $plugin ) );
+				$redirect = add_query_arg( array( 'disabled-auto-update' => 'true' ), $redirect );
+			} else {
+				$plugins = (array) wp_unslash( $_POST['checked'] );
+
+				if ( 'enable-auto-update-selected' === $action ) {
+					$new_auto_updates = array_merge( $auto_updates, $plugins );
+					$new_auto_updates = array_unique( $new_auto_updates );
+					$query_args = array( 'enabled-auto-update-multi' => 'true' );
+				} else {
+					$new_auto_updates = array_diff( $auto_updates, $plugins );
+					$query_args = array( 'disabled-auto-update-multi' => 'true' );
+				}
+
+				// Return early if all selected plugins already have auto-updates enabled or disabled.
+				// Must use non-strict comparison, so that array order is not treated as significant.
+				if ( $new_auto_updates == $auto_updates ) {
+					wp_redirect( $redirect );
+					exit;
+				}
+
+				$auto_updates = $new_auto_updates;
+				$redirect     = add_query_arg( $query_args, $redirect );
 			}
 
 			/** This filter is documented in wp-admin/includes/class-wp-plugins-list-table.php */
 			$all_items    = apply_filters( 'all_plugins', get_plugins() );
-			$auto_updates = (array) get_site_option( 'auto_update_plugins', array() );
 
-			$auto_updates = array_diff( $auto_updates, array( $plugin ) );
-			// Remove plugins that have been deleted since the site option was last updated.
+			// Remove plugins that don't exist or have been deleted since the option was last updated.
 			$auto_updates = array_intersect( $auto_updates, array_keys( $all_items ) );
 
 			update_site_option( 'auto_update_plugins', $auto_updates );
 
-			wp_redirect( self_admin_url( "plugins.php?disable-auto-update=true&plugin_status=$status&paged=$page&s=$s" ) );
-			exit;
-
-		case 'enable-auto-update-selected':
-			if ( ! ( current_user_can( 'update_plugins' ) && wp_is_auto_update_enabled_for_type( 'plugin' ) ) ) {
-				wp_die( __( 'Sorry, you are not allowed to enable plugins automatic updates.' ) );
-			}
-
-			if ( is_multisite() && ! is_network_admin() ) {
-				wp_die( __( 'Please connect to your network admin to manage plugins automatic updates.' ) );
-			}
-
-			check_admin_referer( 'bulk-plugins' );
-
-			$plugins = isset( $_POST['checked'] ) ? (array) wp_unslash( $_POST['checked'] ) : array();
-
-			$auto_updates = (array) get_site_option( 'auto_update_plugins', array() );
-
-			$new_auto_updates = array_merge( $auto_updates, $plugins );
-			$new_auto_updates = array_unique( $new_auto_updates );
-
-			// Return early if all selected plugins already have auto-updates enabled.
-			// Must use non-strict comparison, so that array order is not treated as significant.
-			if ( $new_auto_updates == $auto_updates ) {
-				wp_redirect( self_admin_url( "plugins.php?plugin_status=$status&paged=$page&s=$s" ) );
-				exit;
-			}
-
-			/** This filter is documented in wp-admin/includes/class-wp-plugins-list-table.php */
-			$all_items = apply_filters( 'all_plugins', get_plugins() );
-			// Remove plugins that have been deleted since the site option was last updated.
-			$auto_updates = array_intersect( $new_auto_updates, array_keys( $all_items ) );
-
-			update_site_option( 'auto_update_plugins', $new_auto_updates );
-
-			wp_redirect( self_admin_url( "plugins.php?enable-auto-update-multi=true&plugin_status=$status&paged=$page&s=$s" ) );
-			exit;
-		case 'disable-auto-update-selected':
-			if ( ! ( current_user_can( 'update_plugins' ) && wp_is_auto_update_enabled_for_type( 'plugin' ) ) ) {
-				wp_die( __( 'Sorry, you are not allowed to disable plugins automatic updates.' ) );
-			}
-
-			if ( is_multisite() && ! is_network_admin() ) {
-				wp_die( __( 'Please connect to your network admin to manage plugins automatic updates.' ) );
-			}
-
-			check_admin_referer( 'bulk-plugins' );
-
-			$plugins = isset( $_POST['checked'] ) ? (array) wp_unslash( $_POST['checked'] ) : array();
-
-			$auto_updates     = (array) get_site_option( 'auto_update_plugins', array() );
-			$new_auto_updates = array_diff( $auto_updates, $plugins );
-			$new_auto_updates = array_unique( $new_auto_updates );
-
-			// Return early if all selected plugins already have auto-updates enabled.
-			// Must use non-strict comparison, so that array order is not treated as significant.
-			if ( $new_auto_updates == $auto_updates ) {
-				wp_redirect( self_admin_url( "plugins.php?plugin_status=$status&paged=$page&s=$s" ) );
-				exit;
-			}
-
-			/** This filter is documented in wp-admin/includes/class-wp-plugins-list-table.php */
-			$all_items = apply_filters( 'all_plugins', get_plugins() );
-			// Remove plugins that have been deleted since the site option was last updated.
-			$auto_updates = array_intersect( $new_auto_updates, array_keys( $all_items ) );
-
-			update_site_option( 'auto_update_plugins', $new_auto_updates );
-
-			wp_redirect( self_admin_url( "plugins.php?disable-auto-update-multi=true&plugin_status=$status&paged=$page&s=$s" ) );
+			wp_redirect( $redirect );
 			exit;
 		default:
 			if ( isset( $_POST['checked'] ) ) {
@@ -709,13 +668,13 @@ elseif ( isset( $_GET['deleted'] ) ) :
 	<div id="message" class="updated notice is-dismissible"><p><?php _e( 'All selected plugins are up to date.' ); ?></p></div>
 <?php elseif ( isset( $_GET['resume'] ) ) : ?>
 	<div id="message" class="updated notice is-dismissible"><p><?php _e( 'Plugin resumed.' ); ?></p></div>
-<?php elseif ( isset( $_GET['enable-auto-update'] ) ) : ?>
+<?php elseif ( isset( $_GET['enabled-auto-update'] ) ) : ?>
 	<div id="message" class="updated notice is-dismissible"><p><?php _e( 'Plugin will be auto-updated.' ); ?></p></div>
-<?php elseif ( isset( $_GET['disable-auto-update'] ) ) : ?>
+<?php elseif ( isset( $_GET['disabled-auto-update'] ) ) : ?>
 	<div id="message" class="updated notice is-dismissible"><p><?php _e( 'Plugin will no longer be auto-updated.' ); ?></p></div>
-<?php elseif ( isset( $_GET['enable-auto-update-multi'] ) ) : ?>
+<?php elseif ( isset( $_GET['enabled-auto-update-multi'] ) ) : ?>
 	<div id="message" class="updated notice is-dismissible"><p><?php _e( 'Selected plugins will be auto-updated.' ); ?></p></div>
-<?php elseif ( isset( $_GET['disable-auto-update-multi'] ) ) : ?>
+<?php elseif ( isset( $_GET['disabled-auto-update-multi'] ) ) : ?>
 	<div id="message" class="updated notice is-dismissible"><p><?php _e( 'Selected plugins will no longer be auto-updated.' ); ?></p></div>
 <?php endif; ?>
 

--- a/src/wp-admin/plugins.php
+++ b/src/wp-admin/plugins.php
@@ -35,6 +35,7 @@ $query_args_to_remove = array(
 	'disabled-auto-update-multi',
 	'_error_nonce',
 );
+
 $_SERVER['REQUEST_URI'] = remove_query_arg( $query_args_to_remove, $_SERVER['REQUEST_URI'] );
 
 wp_enqueue_script( 'updates' );
@@ -297,11 +298,14 @@ if ( $action ) {
 			if ( ! isset( $_REQUEST['verify-delete'] ) ) {
 				wp_enqueue_script( 'jquery' );
 				require_once ABSPATH . 'wp-admin/admin-header.php';
+
 				?>
-			<div class="wrap">
+				<div class="wrap">
 				<?php
-					$plugin_info              = array();
-					$have_non_network_plugins = false;
+
+				$plugin_info              = array();
+				$have_non_network_plugins = false;
+
 				foreach ( (array) $plugins as $plugin ) {
 					$plugin_slug = dirname( $plugin );
 
@@ -328,9 +332,11 @@ if ( $action ) {
 						}
 					}
 				}
-					$plugins_to_delete = count( $plugin_info );
+
+				$plugins_to_delete = count( $plugin_info );
+
 				?>
-				<?php if ( 1 == $plugins_to_delete ) : ?>
+				<?php if ( 1 === $plugins_to_delete ) : ?>
 					<h1><?php _e( 'Delete Plugin' ); ?></h1>
 					<?php if ( $have_non_network_plugins && is_network_admin() ) : ?>
 						<div class="error"><p><strong><?php _e( 'Caution:' ); ?></strong> <?php _e( 'This plugin may be active on other sites in the network.' ); ?></p></div>
@@ -345,7 +351,9 @@ if ( $action ) {
 				<?php endif; ?>
 					<ul class="ul-disc">
 						<?php
+
 						$data_to_delete = false;
+
 						foreach ( $plugin_info as $plugin ) {
 							if ( $plugin['is_uninstallable'] ) {
 								/* translators: 1: Plugin name, 2: Plugin author. */
@@ -356,36 +364,44 @@ if ( $action ) {
 								echo '<li>', sprintf( _x( '%1$s by %2$s', 'plugin' ), '<strong>' . $plugin['Name'] . '</strong>', '<em>' . $plugin['AuthorName'] ) . '</em>', '</li>';
 							}
 						}
+
 						?>
 					</ul>
 				<p>
 				<?php
+
 				if ( $data_to_delete ) {
 					_e( 'Are you sure you want to delete these files and data?' );
 				} else {
 					_e( 'Are you sure you want to delete these files?' );
 				}
+
 				?>
 				</p>
 				<form method="post" action="<?php echo esc_url( $_SERVER['REQUEST_URI'] ); ?>" style="display:inline;">
 					<input type="hidden" name="verify-delete" value="1" />
 					<input type="hidden" name="action" value="delete-selected" />
 					<?php
+
 					foreach ( (array) $plugins as $plugin ) {
 						echo '<input type="hidden" name="checked[]" value="' . esc_attr( $plugin ) . '" />';
 					}
+
 					?>
 					<?php wp_nonce_field( 'bulk-plugins' ); ?>
 					<?php submit_button( $data_to_delete ? __( 'Yes, delete these files and data' ) : __( 'Yes, delete these files' ), '', 'submit', false ); ?>
 				</form>
 				<?php
+
 				$referer = wp_get_referer();
+
 				?>
 				<form method="post" action="<?php echo $referer ? esc_url( $referer ) : ''; ?>" style="display:inline;">
 					<?php submit_button( __( 'No, return me to the plugin list' ), '', 'submit', false ); ?>
 				</form>
-			</div>
+				</div>
 				<?php
+
 				require_once ABSPATH . 'wp-admin/admin-footer.php';
 				exit;
 			} else {
@@ -398,15 +414,14 @@ if ( $action ) {
 			set_transient( 'plugins_delete_result_' . $user_ID, $delete_result );
 			wp_redirect( self_admin_url( "plugins.php?deleted=$plugins_to_delete&plugin_status=$status&paged=$page&s=$s" ) );
 			exit;
-
 		case 'clear-recent-list':
 			if ( ! is_network_admin() ) {
 				update_option( 'recently_activated', array() );
 			} else {
 				update_site_option( 'recently_activated', array() );
 			}
-			break;
 
+			break;
 		case 'resume':
 			if ( is_multisite() ) {
 				return;
@@ -426,7 +441,6 @@ if ( $action ) {
 
 			wp_redirect( self_admin_url( "plugins.php?resume=true&plugin_status=$status&paged=$page&s=$s" ) );
 			exit;
-
 		case 'enable-auto-update':
 		case 'disable-auto-update':
 		case 'enable-auto-update-selected':
@@ -462,25 +476,25 @@ if ( $action ) {
 			if ( 'enable-auto-update' === $action ) {
 				$auto_updates[] = $plugin;
 				$auto_updates   = array_unique( $auto_updates );
-				$redirect = add_query_arg( array( 'enabled-auto-update' => 'true' ), $redirect );
+				$redirect       = add_query_arg( array( 'enabled-auto-update' => 'true' ), $redirect );
 			} elseif ( 'disable-auto-update' === $action ) {
 				$auto_updates = array_diff( $auto_updates, array( $plugin ) );
-				$redirect = add_query_arg( array( 'disabled-auto-update' => 'true' ), $redirect );
+				$redirect     = add_query_arg( array( 'disabled-auto-update' => 'true' ), $redirect );
 			} else {
 				$plugins = (array) wp_unslash( $_POST['checked'] );
 
 				if ( 'enable-auto-update-selected' === $action ) {
 					$new_auto_updates = array_merge( $auto_updates, $plugins );
 					$new_auto_updates = array_unique( $new_auto_updates );
-					$query_args = array( 'enabled-auto-update-multi' => 'true' );
+					$query_args       = array( 'enabled-auto-update-multi' => 'true' );
 				} else {
 					$new_auto_updates = array_diff( $auto_updates, $plugins );
-					$query_args = array( 'disabled-auto-update-multi' => 'true' );
+					$query_args       = array( 'disabled-auto-update-multi' => 'true' );
 				}
 
 				// Return early if all selected plugins already have auto-updates enabled or disabled.
 				// Must use non-strict comparison, so that array order is not treated as significant.
-				if ( $new_auto_updates == $auto_updates ) {
+				if ( $new_auto_updates == $auto_updates ) { // phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison
 					wp_redirect( $redirect );
 					exit;
 				}
@@ -490,7 +504,7 @@ if ( $action ) {
 			}
 
 			/** This filter is documented in wp-admin/includes/class-wp-plugins-list-table.php */
-			$all_items    = apply_filters( 'all_plugins', get_plugins() );
+			$all_items = apply_filters( 'all_plugins', get_plugins() );
 
 			// Remove plugins that don't exist or have been deleted since the option was last updated.
 			$auto_updates = array_intersect( $auto_updates, array_keys( $all_items ) );
@@ -583,9 +597,7 @@ if ( ! empty( $invalid ) ) {
 		echo '</p></div>';
 	}
 }
-?>
 
-<?php
 if ( isset( $_GET['error'] ) ) :
 
 	if ( isset( $_GET['main'] ) ) {
@@ -606,9 +618,11 @@ if ( isset( $_GET['error'] ) ) :
 	} else {
 		$errmsg = __( 'Plugin could not be activated because it triggered a <strong>fatal error</strong>.' );
 	}
+
 	?>
 	<div id="message" class="error"><p><?php echo $errmsg; ?></p>
 	<?php
+
 	if ( ! isset( $_GET['main'] ) && ! isset( $_GET['charsout'] ) && wp_verify_nonce( $_GET['_error_nonce'], 'plugin-activation-error_' . $plugin ) ) {
 		$iframe_url = add_query_arg(
 			array(
@@ -618,17 +632,19 @@ if ( isset( $_GET['error'] ) ) :
 			),
 			admin_url( 'plugins.php' )
 		);
+
 		?>
-	<iframe style="border:0" width="100%" height="70px" src="<?php echo esc_url( $iframe_url ); ?>"></iframe>
+		<iframe style="border:0" width="100%" height="70px" src="<?php echo esc_url( $iframe_url ); ?>"></iframe>
 		<?php
 	}
+
 	?>
 	</div>
 	<?php
 elseif ( isset( $_GET['deleted'] ) ) :
-		$delete_result = get_transient( 'plugins_delete_result_' . $user_ID );
-		// Delete it once we're done.
-		delete_transient( 'plugins_delete_result_' . $user_ID );
+	$delete_result = get_transient( 'plugins_delete_result_' . $user_ID );
+	// Delete it once we're done.
+	delete_transient( 'plugins_delete_result_' . $user_ID );
 
 	if ( is_wp_error( $delete_result ) ) :
 		?>
@@ -647,7 +663,7 @@ elseif ( isset( $_GET['deleted'] ) ) :
 		<div id="message" class="updated notice is-dismissible">
 			<p>
 				<?php
-				if ( 1 == (int) $_GET['deleted'] ) {
+				if ( 1 === (int) $_GET['deleted'] ) {
 					_e( 'The selected plugin has been deleted.' );
 				} else {
 					_e( 'The selected plugins have been deleted.' );
@@ -655,7 +671,7 @@ elseif ( isset( $_GET['deleted'] ) ) :
 				?>
 			</p>
 		</div>
-		<?php endif; ?>
+	<?php endif; ?>
 <?php elseif ( isset( $_GET['activate'] ) ) : ?>
 	<div id="message" class="updated notice is-dismissible"><p><?php _e( 'Plugin activated.' ); ?></p></div>
 <?php elseif ( isset( $_GET['activate-multi'] ) ) : ?>

--- a/src/wp-content/themes/twentytwenty/style.css
+++ b/src/wp-content/themes/twentytwenty/style.css
@@ -3530,6 +3530,11 @@ figure.wp-block-table.is-style-stripes {
 	margin: 4rem auto;
 }
 
+.post-inner .entry-content > .wp-block-cover.alignwide:first-child,
+.post-inner .entry-content > .wp-block-cover.alignfull:first-child {
+	margin-top: 0;
+}
+
 /* Font Families ----------------------------- */
 
 .entry-content {
@@ -5408,6 +5413,11 @@ a.to-the-top > * {
 		margin-right: 4rem;
 	}
 
+	.entry-content > .alignwide:first-child,
+	.entry-content > .alignfull:first-child {
+		margin-bottom: 8rem;
+	}
+
 	/* ENTRY MEDIA */
 
 	.alignfull > figcaption,
@@ -5917,7 +5927,7 @@ a.to-the-top > * {
 		/*rtl:ignore*/
 		margin-left: 0;
 	}
-  
+
     .wp-block-image .aligncenter figcaption {
         text-align: center;
     }

--- a/src/wp-includes/class-wp-customize-manager.php
+++ b/src/wp-includes/class-wp-customize-manager.php
@@ -889,7 +889,7 @@ final class WP_Customize_Manager {
 	 * @return bool
 	 */
 	public function is_theme_active() {
-		return $this->get_stylesheet() == $this->original_stylesheet;
+		return $this->get_stylesheet() === $this->original_stylesheet;
 	}
 
 	/**
@@ -5856,8 +5856,8 @@ final class WP_Customize_Manager {
 				$theme->id            = $theme->slug;
 				$theme->screenshot    = array( $theme->screenshot_url );
 				$theme->authorAndUri  = wp_kses( $theme->author['display_name'], $themes_allowedtags );
-				$theme->compatibleWP  = is_wp_version_compatible( $theme->requires );
-				$theme->compatiblePHP = is_php_version_compatible( $theme->requires_php );
+				$theme->compatibleWP  = is_wp_version_compatible( $theme->requires ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName
+				$theme->compatiblePHP = is_php_version_compatible( $theme->requires_php ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName
 
 				if ( isset( $theme->parent ) ) {
 					$theme->parent = $theme->parent['slug'];


### PR DESCRIPTION
- Remove `wp-autoupdates` from tranlsated strings.
- Shorten some var names.
- Use `add_query_arg()` for some URLs in the list tables.
- Shorten couple of very long printf() HTML strings.
- Set couple of translated strings to vars instead of calling the functions in a loop.